### PR TITLE
fix(AGStoSHP) url 'query' bug

### DIFF
--- a/AGStoSHP.js
+++ b/AGStoSHP.js
@@ -38,7 +38,7 @@ fs.readFile(serviceFile, function (err, data) {
 	data.toString().split('\n').forEach(function (service) {
 		var service = service.split('|');
 		if(service[0].split('').length == 0) return;
-		var baseUrl = getBaseUrl(service[0].trim()) + '/query';
+		var baseUrl = getBaseUrl(service[0].trim());
 
 		var reqQS = {
 			where: '1=1',


### PR DESCRIPTION
There is a bug where we are appending a `/query` string to the url twice. Once here: https://github.com/tannerjt/AGStoShapefile/blob/master/AGStoSHP.js#L41 and again here: https://github.com/tannerjt/AGStoShapefile/blob/master/AGStoSHP.js#L52

this PR fixes that error.